### PR TITLE
feat(cb2-6025): remove test station name truncation

### DIFF
--- a/src/services/extractVehicleBooking.ts
+++ b/src/services/extractVehicleBooking.ts
@@ -20,14 +20,6 @@ const trimTestCode = (testCode: string | undefined): string => {
   return testCode.toUpperCase();
 };
 
-const trimTestStationName = (testStationName: string): string => {
-  if (testStationName.length > 10) {
-    return testStationName.slice(0, 10);
-  }
-
-  return testStationName;
-};
-
 export const extractVehicleBookings = (
   event: DynamoDBStreamEvent,
 ): Booking[] => {
@@ -76,7 +68,7 @@ export const extractBookingDetails = (testResult: TestResult): Booking[] => {
       if (testResult.vehicleType === 'trl') {
         if (testResult.trailerId) {
           return {
-            name: trimTestStationName(testResult.testStationName),
+            name: testResult.testStationName,
             bookingDate: dateFormat(testResult.testStartTimestamp, 'isoDate'),
             vrm: testResult.trailerId,
             testCode: trimTestCode(testType.testCode),
@@ -90,7 +82,7 @@ export const extractBookingDetails = (testResult: TestResult): Booking[] => {
 
       if (testResult.vrm) {
         return {
-          name: trimTestStationName(testResult.testStationName),
+          name: testResult.testStationName,
           bookingDate: dateFormat(testResult.testStartTimestamp, 'isoDate'),
           vrm: testResult.vrm,
           testCode: trimTestCode(testType.testCode),

--- a/tests/integration/dynamo.intTest.ts
+++ b/tests/integration/dynamo.intTest.ts
@@ -53,7 +53,7 @@ describe('Handler integration test', () => {
         <EventEntry>{
           Source: config.aws.eventBusSource,
           Detail:
-            '{"name":"Rowe, Wuns","bookingDate":"2021-01-14","vrm":"JY58FPP","testCode":"FFV","testDate":"2021-01-14","pNumber":"87-1369569"}',
+            '{"name":"Rowe, Wunsch and Wisoky","bookingDate":"2021-01-14","vrm":"JY58FPP","testCode":"FFV","testDate":"2021-01-14","pNumber":"87-1369569"}',
           DetailType: 'CVS Test Booking',
           EventBusName: config.aws.eventBusName,
           Time: new Date('2022-01-01'),
@@ -66,7 +66,7 @@ describe('Handler integration test', () => {
         <EventEntry>{
           Source: config.aws.eventBusSource,
           Detail:
-            '{"name":"Rowe, Wuns","bookingDate":"2021-01-14","vrm":"JY58FPP","testCode":"LEC","testDate":"2021-01-14","pNumber":"87-1369569"}',
+            '{"name":"Rowe, Wunsch and Wisoky","bookingDate":"2021-01-14","vrm":"JY58FPP","testCode":"LEC","testDate":"2021-01-14","pNumber":"87-1369569"}',
           DetailType: 'CVS Test Booking',
           EventBusName: config.aws.eventBusName,
           Time: new Date('2022-01-01'),

--- a/tests/unit/services/extractVehicleBooking.test.ts
+++ b/tests/unit/services/extractVehicleBooking.test.ts
@@ -16,7 +16,7 @@ describe('extractVehicleBooking', () => {
 
     expect(result).toHaveLength(2);
     expect(result[0]).toEqual({
-      name: 'Rowe, Wuns',
+      name: 'Rowe, Wunsch and Wisoky',
       bookingDate: '2021-01-14',
       vrm: 'JY58FPP',
       testDate: '2021-01-14',
@@ -24,7 +24,7 @@ describe('extractVehicleBooking', () => {
       pNumber: '87-1369569',
     });
     expect(result[1]).toEqual({
-      name: 'Rowe, Wuns',
+      name: 'Rowe, Wunsch and Wisoky',
       bookingDate: '2021-01-14',
       vrm: 'JY58FPP',
       testDate: '2021-01-14',


### PR DESCRIPTION
## Description

The test station name is now used in a couple of places. Inserting into the VEHICLE_BOOKING table (10 character limit) and now into the BOOKING_HEADER table (50 character limit). Therefore, the truncation has been moved to the vt-booking function.

Related issue: [CB2-6025](https://dvsa.atlassian.net/browse/CB2-6025)