### PR TITLE
fix(cb2-6341 & cb2-6344): 

### DIFF
--- a/src/interfaces/Booking.ts
+++ b/src/interfaces/Booking.ts
@@ -1,7 +1,8 @@
 export interface Booking {
   name: string;
   bookingDate: string;
-  vrm: string;
+  vrm?: string;
+  trailerId?: string;
   testCode: string;
   testDate: string;
   pNumber: string;

--- a/src/services/extractVehicleBooking.ts
+++ b/src/services/extractVehicleBooking.ts
@@ -69,10 +69,10 @@ export const extractBookingDetails = (testResult: TestResult): Booking[] => {
         if (testResult.trailerId) {
           return {
             name: testResult.testStationName,
-            bookingDate: dateFormat(testResult.testStartTimestamp, 'isoDate'),
+            bookingDate: dateFormat(testResult.testStartTimestamp, 'yyyy-mm-dd HH:MM:ss'),
             trailerId: testResult.trailerId,
             testCode: trimTestCode(testType.testCode),
-            testDate: dateFormat(testResult.testStartTimestamp, 'isoDate'),
+            testDate: dateFormat(testType.testTypeStartTimestamp,'yyyy-mm-dd HH:MM:ss'),
             pNumber: testResult.testStationPNumber,
           };
         }
@@ -83,10 +83,13 @@ export const extractBookingDetails = (testResult: TestResult): Booking[] => {
       if (testResult.vrm) {
         return {
           name: testResult.testStationName,
-          bookingDate: dateFormat(testResult.testStartTimestamp, 'isoDate'),
+          bookingDate: dateFormat(
+            testResult.testStartTimestamp,
+            'yyyy-mm-dd HH:MM:ss',
+          ),
           vrm: testResult.vrm,
           testCode: trimTestCode(testType.testCode),
-          testDate: dateFormat(testResult.testStartTimestamp, 'isoDate'),
+          testDate: dateFormat(testType.testTypeStartTimestamp,'yyyy-mm-dd HH:MM:ss'),
           pNumber: testResult.testStationPNumber,
         };
       }

--- a/src/services/extractVehicleBooking.ts
+++ b/src/services/extractVehicleBooking.ts
@@ -70,7 +70,7 @@ export const extractBookingDetails = (testResult: TestResult): Booking[] => {
           return {
             name: testResult.testStationName,
             bookingDate: dateFormat(testResult.testStartTimestamp, 'isoDate'),
-            vrm: testResult.trailerId,
+            trailerId: testResult.trailerId,
             testCode: trimTestCode(testType.testCode),
             testDate: dateFormat(testResult.testStartTimestamp, 'isoDate'),
             pNumber: testResult.testStationPNumber,

--- a/src/services/extractVehicleBooking.ts
+++ b/src/services/extractVehicleBooking.ts
@@ -69,10 +69,16 @@ export const extractBookingDetails = (testResult: TestResult): Booking[] => {
         if (testResult.trailerId) {
           return {
             name: testResult.testStationName,
-            bookingDate: dateFormat(testResult.testStartTimestamp, 'yyyy-mm-dd HH:MM:ss'),
+            bookingDate: dateFormat(
+              testResult.testStartTimestamp,
+              'yyyy-mm-dd HH:MM:ss',
+            ),
             trailerId: testResult.trailerId,
             testCode: trimTestCode(testType.testCode),
-            testDate: dateFormat(testType.testTypeStartTimestamp,'yyyy-mm-dd HH:MM:ss'),
+            testDate: dateFormat(
+              testType.testTypeStartTimestamp,
+              'yyyy-mm-dd HH:MM:ss',
+            ),
             pNumber: testResult.testStationPNumber,
           };
         }
@@ -89,7 +95,10 @@ export const extractBookingDetails = (testResult: TestResult): Booking[] => {
           ),
           vrm: testResult.vrm,
           testCode: trimTestCode(testType.testCode),
-          testDate: dateFormat(testType.testTypeStartTimestamp,'yyyy-mm-dd HH:MM:ss'),
+          testDate: dateFormat(
+            testType.testTypeStartTimestamp,
+            'yyyy-mm-dd HH:MM:ss',
+          ),
           pNumber: testResult.testStationPNumber,
         };
       }

--- a/tests/integration/dynamo.intTest.ts
+++ b/tests/integration/dynamo.intTest.ts
@@ -32,7 +32,7 @@ jest.mock('aws-sdk', () => ({
 
 jest.mock('../../src/util/logger');
 
-const mockDate = new Date('2021-01-14');
+const mockDate = new Date('2021-01-14T10:36:33.987Z');
 jest
   .spyOn(global, 'Date')
   .mockImplementation(() => mockDate as unknown as string);
@@ -53,7 +53,7 @@ describe('Handler integration test', () => {
         <EventEntry>{
           Source: config.aws.eventBusSource,
           Detail:
-            '{"name":"Rowe, Wunsch and Wisoky","bookingDate":"2021-01-14 12:00:00","vrm":"JY58FPP","testCode":"FFV","testDate":"2021-01-14","pNumber":"87-1369569"}',
+            '{"name":"Rowe, Wunsch and Wisoky","bookingDate":"2021-01-14 10:36:33","vrm":"JY58FPP","testCode":"FFV","testDate":"2021-01-14 10:36:33","pNumber":"87-1369569"}',
           DetailType: 'CVS Test Booking',
           EventBusName: config.aws.eventBusName,
           Time: new Date('2022-01-01'),
@@ -66,7 +66,7 @@ describe('Handler integration test', () => {
         <EventEntry>{
           Source: config.aws.eventBusSource,
           Detail:
-            '{"name":"Rowe, Wunsch and Wisoky","bookingDate":"2021-01-14","vrm":"JY58FPP","testCode":"LEC","testDate":"2021-01-14","pNumber":"87-1369569"}',
+            '{"name":"Rowe, Wunsch and Wisoky","bookingDate":"2021-01-14 10:36:33","vrm":"JY58FPP","testCode":"LEC","testDate":"2021-01-14 10:36:33","pNumber":"87-1369569"}',
           DetailType: 'CVS Test Booking',
           EventBusName: config.aws.eventBusName,
           Time: new Date('2022-01-01'),

--- a/tests/integration/dynamo.intTest.ts
+++ b/tests/integration/dynamo.intTest.ts
@@ -53,7 +53,7 @@ describe('Handler integration test', () => {
         <EventEntry>{
           Source: config.aws.eventBusSource,
           Detail:
-            '{"name":"Rowe, Wunsch and Wisoky","bookingDate":"2021-01-14","vrm":"JY58FPP","testCode":"FFV","testDate":"2021-01-14","pNumber":"87-1369569"}',
+            '{"name":"Rowe, Wunsch and Wisoky","bookingDate":"2021-01-14 12:00:00","vrm":"JY58FPP","testCode":"FFV","testDate":"2021-01-14","pNumber":"87-1369569"}',
           DetailType: 'CVS Test Booking',
           EventBusName: config.aws.eventBusName,
           Time: new Date('2022-01-01'),

--- a/tests/unit/resources/mTestResultRecords.ts
+++ b/tests/unit/resources/mTestResultRecords.ts
@@ -156,8 +156,8 @@ export const GetDynamoStream = (i: number): DynamoDBStreamEvent => {
                           S: 'art',
                         },
                         testTypeStartTimestamp: {
-                          S: '2021-01-15T10:36:33.987Z'
-                        }
+                          S: '2021-01-15T10:36:33.987Z',
+                        },
                       },
                     },
                     {
@@ -166,8 +166,8 @@ export const GetDynamoStream = (i: number): DynamoDBStreamEvent => {
                           S: 'aat1',
                         },
                         testTypeStartTimestamp: {
-                          S: '2021-01-14T10:36:33.987Z'
-                        }
+                          S: '2021-01-14T10:36:33.987Z',
+                        },
                       },
                     },
                   ],
@@ -207,8 +207,8 @@ export const GetDynamoStream = (i: number): DynamoDBStreamEvent => {
                           S: 'art',
                         },
                         testTypeStartTimestamp: {
-                          S: '2021-01-15T10:36:33.987Z'
-                        }
+                          S: '2021-01-15T10:36:33.987Z',
+                        },
                       },
                     },
                     {
@@ -217,8 +217,8 @@ export const GetDynamoStream = (i: number): DynamoDBStreamEvent => {
                           S: 'aat1',
                         },
                         testTypeStartTimestamp: {
-                          S: '2021-01-14T10:36:33.987Z'
-                        }
+                          S: '2021-01-14T10:36:33.987Z',
+                        },
                       },
                     },
                   ],
@@ -258,8 +258,8 @@ export const GetDynamoStream = (i: number): DynamoDBStreamEvent => {
                           S: 'ffv2',
                         },
                         testTypeStartTimestamp: {
-                          S: '2021-01-14T10:36:33.987Z'
-                        }
+                          S: '2021-01-14T10:36:33.987Z',
+                        },
                       },
                     },
                     {
@@ -268,8 +268,8 @@ export const GetDynamoStream = (i: number): DynamoDBStreamEvent => {
                           S: 'lec',
                         },
                         testTypeStartTimestamp: {
-                          S: '2021-01-15T10:36:33.987Z'
-                        }
+                          S: '2021-01-15T10:36:33.987Z',
+                        },
                       },
                     },
                   ],
@@ -309,8 +309,8 @@ export const GetDynamoStream = (i: number): DynamoDBStreamEvent => {
                           S: 'ffva',
                         },
                         testTypeStartTimestamp: {
-                          S: '2021-01-14T10:36:33.987Z'
-                        }
+                          S: '2021-01-14T10:36:33.987Z',
+                        },
                       },
                     },
                   ],
@@ -356,8 +356,8 @@ export const GetDynamoStream = (i: number): DynamoDBStreamEvent => {
                           S: 'ffv2',
                         },
                         testTypeStartTimestamp: {
-                          S: '2021-01-14T10:36:33.987Z'
-                        }
+                          S: '2021-01-14T10:36:33.987Z',
+                        },
                       },
                     },
                     {
@@ -366,8 +366,8 @@ export const GetDynamoStream = (i: number): DynamoDBStreamEvent => {
                           S: 'lec',
                         },
                         testTypeStartTimestamp: {
-                          S: '2021-01-14T10:36:33.987Z'
-                        }
+                          S: '2021-01-14T10:36:33.987Z',
+                        },
                       },
                     },
                   ],

--- a/tests/unit/resources/mTestResultRecords.ts
+++ b/tests/unit/resources/mTestResultRecords.ts
@@ -34,12 +34,18 @@ export const GetDynamoStream = (i: number): DynamoDBStreamEvent => {
                         testCode: {
                           S: 'ffv2',
                         },
+                        testTypeStartTimestamp: {
+                          S: '2021-01-14T15:36:33.987Z',
+                        },
                       },
                     },
                     {
                       M: {
                         testCode: {
                           S: 'lec',
+                        },
+                        testTypeStartTimestamp: {
+                          S: '2021-01-14T10:36:33.987Z',
                         },
                       },
                     },
@@ -82,12 +88,18 @@ export const GetDynamoStream = (i: number): DynamoDBStreamEvent => {
                         testCode: {
                           S: 'art',
                         },
+                        testTypeStartTimestamp: {
+                          S: '2021-01-15T10:36:33.987Z',
+                        },
                       },
                     },
                     {
                       M: {
                         testCode: {
                           S: 'aat1',
+                        },
+                        testTypeStartTimestamp: {
+                          S: '2021-01-14T10:36:33.987Z',
                         },
                       },
                     },
@@ -143,6 +155,9 @@ export const GetDynamoStream = (i: number): DynamoDBStreamEvent => {
                         testCode: {
                           S: 'art',
                         },
+                        testTypeStartTimestamp: {
+                          S: '2021-01-15T10:36:33.987Z'
+                        }
                       },
                     },
                     {
@@ -150,6 +165,9 @@ export const GetDynamoStream = (i: number): DynamoDBStreamEvent => {
                         testCode: {
                           S: 'aat1',
                         },
+                        testTypeStartTimestamp: {
+                          S: '2021-01-14T10:36:33.987Z'
+                        }
                       },
                     },
                   ],
@@ -188,6 +206,9 @@ export const GetDynamoStream = (i: number): DynamoDBStreamEvent => {
                         testCode: {
                           S: 'art',
                         },
+                        testTypeStartTimestamp: {
+                          S: '2021-01-15T10:36:33.987Z'
+                        }
                       },
                     },
                     {
@@ -195,6 +216,9 @@ export const GetDynamoStream = (i: number): DynamoDBStreamEvent => {
                         testCode: {
                           S: 'aat1',
                         },
+                        testTypeStartTimestamp: {
+                          S: '2021-01-14T10:36:33.987Z'
+                        }
                       },
                     },
                   ],
@@ -233,6 +257,9 @@ export const GetDynamoStream = (i: number): DynamoDBStreamEvent => {
                         testCode: {
                           S: 'ffv2',
                         },
+                        testTypeStartTimestamp: {
+                          S: '2021-01-14T10:36:33.987Z'
+                        }
                       },
                     },
                     {
@@ -240,6 +267,9 @@ export const GetDynamoStream = (i: number): DynamoDBStreamEvent => {
                         testCode: {
                           S: 'lec',
                         },
+                        testTypeStartTimestamp: {
+                          S: '2021-01-15T10:36:33.987Z'
+                        }
                       },
                     },
                   ],
@@ -278,6 +308,9 @@ export const GetDynamoStream = (i: number): DynamoDBStreamEvent => {
                         testCode: {
                           S: 'ffva',
                         },
+                        testTypeStartTimestamp: {
+                          S: '2021-01-14T10:36:33.987Z'
+                        }
                       },
                     },
                   ],
@@ -322,6 +355,9 @@ export const GetDynamoStream = (i: number): DynamoDBStreamEvent => {
                         testCode: {
                           S: 'ffv2',
                         },
+                        testTypeStartTimestamp: {
+                          S: '2021-01-14T10:36:33.987Z'
+                        }
                       },
                     },
                     {
@@ -329,6 +365,9 @@ export const GetDynamoStream = (i: number): DynamoDBStreamEvent => {
                         testCode: {
                           S: 'lec',
                         },
+                        testTypeStartTimestamp: {
+                          S: '2021-01-14T10:36:33.987Z'
+                        }
                       },
                     },
                   ],

--- a/tests/unit/services/extractVehicleBooking.test.ts
+++ b/tests/unit/services/extractVehicleBooking.test.ts
@@ -17,17 +17,17 @@ describe('extractVehicleBooking', () => {
     expect(result).toHaveLength(2);
     expect(result[0]).toEqual({
       name: 'Rowe, Wunsch and Wisoky',
-      bookingDate: '2021-01-14',
+      bookingDate: '2021-01-14 10:36:33',
       vrm: 'JY58FPP',
-      testDate: '2021-01-14',
+      testDate: '2021-01-14 15:36:33',
       testCode: 'FFV',
       pNumber: '87-1369569',
     });
     expect(result[1]).toEqual({
       name: 'Rowe, Wunsch and Wisoky',
-      bookingDate: '2021-01-14',
+      bookingDate: '2021-01-14 10:36:33',
       vrm: 'JY58FPP',
-      testDate: '2021-01-14',
+      testDate: '2021-01-14 10:36:33',
       testCode: 'LEC',
       pNumber: '87-1369569',
     });
@@ -41,17 +41,17 @@ describe('extractVehicleBooking', () => {
     expect(result).toHaveLength(2);
     expect(result[0]).toEqual({
       name: 'MyATF',
-      bookingDate: '2021-01-14',
+      bookingDate: '2021-01-14 10:36:33',
       trailerId: 'C000001',
-      testDate: '2021-01-14',
+      testDate: '2021-01-15 10:36:33',
       testCode: 'ART',
       pNumber: '87-1369569',
     });
     expect(result[1]).toEqual({
       name: 'MyATF',
-      bookingDate: '2021-01-14',
+      bookingDate: '2021-01-14 10:36:33',
       trailerId: 'C000001',
-      testDate: '2021-01-14',
+      testDate: '2021-01-14 10:36:33',
       testCode: 'AAT',
       pNumber: '87-1369569',
     });

--- a/tests/unit/services/extractVehicleBooking.test.ts
+++ b/tests/unit/services/extractVehicleBooking.test.ts
@@ -42,7 +42,7 @@ describe('extractVehicleBooking', () => {
     expect(result[0]).toEqual({
       name: 'MyATF',
       bookingDate: '2021-01-14',
-      vrm: 'C000001',
+      trailerId: 'C000001',
       testDate: '2021-01-14',
       testCode: 'ART',
       pNumber: '87-1369569',
@@ -50,7 +50,7 @@ describe('extractVehicleBooking', () => {
     expect(result[1]).toEqual({
       name: 'MyATF',
       bookingDate: '2021-01-14',
-      vrm: 'C000001',
+      trailerId: 'C000001',
       testDate: '2021-01-14',
       testCode: 'AAT',
       pNumber: '87-1369569',


### PR DESCRIPTION
## Description

Change payload of SQS event to facilitate [CB2-6341](https://dvsa.atlassian.net/browse/CB2-6341) and [CB2-6344](https://dvsa.atlassian.net/browse/CB2-6344) bug fixes:
  -  Amend `bookingDate` and `testDate` to be in `yyyy-mm-dd HH:MM:ss` format instead of an `isoDate`
  - Amend `testDate` on SQS event to contain the `testTypeStartTimestamp` attribute instead of `testStartTimestamp` so that multiple test bookings can be made on a singular day. 
  - If a test has been carried out on a trailer, send the `trailerId` within it's own `trailerId` attribute in the SQS event - not `vrm`. This allows the vt-booking lambda to distinguish whether the test was carried out on a trailer or not.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have added tests that prove my fix is effective or that my feature works

## Evidence of Completion
Clean database.

![image](https://user-images.githubusercontent.com/13391709/197721156-277a216d-c0c2-4594-9a9c-b91fa9b7e1a3.png)
PSV record inserted into dynamo table with lbp and nvv tests at 09:36 and 10:36 respectively.

![image](https://user-images.githubusercontent.com/13391709/197721620-07765eec-6d59-481c-98ca-646e3d29c097.png)
Two bookings sent to the eventbridge.

![image](https://user-images.githubusercontent.com/13391709/197722605-d28da5b6-4a3a-4e8a-aaab-9ac25c0545ea.png)
Two events received by the vt-booking function.

![image](https://user-images.githubusercontent.com/13391709/197723210-6a6187af-3f1e-4ee9-bc97-71d09c2f23a2.png)
![image](https://user-images.githubusercontent.com/13391709/197723628-93e9ed02-0fc5-477d-9929-72baa76ae478.png)
(Note that the messages have vrm and no trailerId properties)

Trailer record inserted into dynamo table with aat test at 13:36.
![image](https://user-images.githubusercontent.com/13391709/197725323-5da01a67-db69-4544-a0e0-bc6c53d52746.png)

One event received by the vt-booking function.
![image](https://user-images.githubusercontent.com/13391709/197726947-8d3048c5-7bef-44ae-a3dd-ab59d2ea5ff1.png)
(Note that the message has a trailerId and no vrm property)

All three tests have bookings in the database.
![image](https://user-images.githubusercontent.com/13391709/197726632-c5ca6d8f-2a6b-4bc8-908c-fa82de3c3ca1.png)
